### PR TITLE
Add support for converting from MARCXML

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/edsu/marctable/actions/workflows/test.yml/badge.svg)](https://github.com/edsu/marctable/actions/workflows/test.yml)
 
-*marctable* is a Python command line utility that converts MARC bibliographic data into tabular formats like [CSV] and [Parquet]. It uses the Library of Congress [MARC Bibliographic documentation] expressed as an [Avram] [JSON file] to determine what MARC fields and subfields to include and whether they can repeat or not.
+*marctable* is a Python command line utility that converts MARC bibliographic data (in transmission format or MARCXML) into tabular formats like [CSV] and [Parquet]. It uses the Library of Congress [MARC Bibliographic documentation] expressed as an [Avram] [JSON file] to determine what MARC fields and subfields to include and whether they can repeat or not.
 
 ## Install
 

--- a/marctable/utils.py
+++ b/marctable/utils.py
@@ -84,8 +84,14 @@ def records_iter(
     mapping = _mapping(rules)
     marc = MARC.from_avram()
 
+    # TODO: MARCXML parsing brings all the records into memory
+    if marc_input.name.endswith(".xml"):
+        reader = pymarc.marcxml.parse_xml_to_array(marc_input)
+    else:
+        reader = pymarc.MARCReader(marc_input)
+
     rows = []
-    for record in pymarc.MARCReader(marc_input):
+    for record in reader:
         # if pymarc can't make sense of a record it returns None
         if record is None:
             # TODO: log this?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "marctable"
-version = "0.3.2"
+version = "0.4.0"
 description = "Convert MARC to CSV and Parquet"
 authors = ["Ed Summers <ehs@pobox.com>"]
 license = "Apache"

--- a/test_marctable.py
+++ b/test_marctable.py
@@ -165,3 +165,19 @@ def test_to_parquet_with_rules() -> None:
     df = pandas.read_parquet("test-data/utf8.parquet")
     assert len(df) == 10612
     assert len(df.columns) == 3
+
+
+def test_xml() -> None:
+    # this mirrors test_df, but works off of the MARCXML instead
+    df = to_dataframe(open("test-data/marc.xml", "rb"))
+    assert len(df.columns) == 215
+    assert len(df) == 10631
+    assert df.iloc[0]["F008"] == "000110s2000    ohu    f   m        eng  "
+    # 245 is not repeatable
+    assert (
+        df.iloc[0]["F245"]
+        == "Leak testing CD-ROM [computer file] / technical editors, Charles N. "
+        "Jackson, Jr., Charles N. Sherlock ; editor, Patrick O. Moore."
+    )
+    # 650 is repeatable
+    assert df.iloc[0]["F650"] == ["Leak detectors.", "Gas leakage."]


### PR DESCRIPTION
This adds support for converting MARCXML files. It uses pymarc's `pymarc.marcxml.parse_xml_to_array` so it will read all the records in the XML file into memory, and then convert them.

Fixes #9
