### PR TITLE
Allow for fields and subfields

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       uses: chartboost/ruff-action@v1
 
     - name: Check types
-      run: uv run mypy src 
+      run: uv run ty check src 
 
     - name: Run tests
       run: uv run pytest -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "marctable"
-version = "0.6.0"
+version = "0.7.0"
 description = "Convert MARC to CSV and Parquet"
 authors = [{ name = "Ed Summers", email = "ehs@pobox.com" }]
 license = { file = "LICENSE" }
@@ -26,11 +26,11 @@ dev = [
     "pytest>=7.4.3",
     "types-requests >= 2.31.0.10",
     "types-beautifulsoup4 >= 4.12.0.7",
-    "mypy >= 1.8.0",
     "pandas-stubs >= 2.1.4.231227",
     "pyarrow-stubs >= 10.0.1.7",
     "ruff>=0.9.6",
     "setuptools>=75.8.0",
+    "ty>=0.0.31",
 ]
 
 [build-system]

--- a/src/marctable/marc.py
+++ b/src/marctable/marc.py
@@ -32,7 +32,7 @@ class Subfield:
     def from_dict(cls: Type["Subfield"], d: dict) -> "Subfield":
         return Subfield(d["code"], d["label"], d["repeatable"])
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, str | bool]:
         return {"code": self.code, "label": self.label, "repeatable": self.repeatable}
 
 
@@ -70,7 +70,7 @@ class Field:
             subfields=[Subfield.from_dict(d) for d in d.get("subfields", {}).values()],
         )
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, str | bool | None]:
         d = {
             "tag": self.tag,
             "label": self.label,
@@ -79,7 +79,7 @@ class Field:
         }
 
         if self.subfields is not None:
-            d["subfields"] = {sf.code: sf.to_dict() for sf in self.subfields}
+            d["subfields"]: dict[str, dict] = {sf.code: sf.to_dict() for sf in self.subfields}
 
         return d
 

--- a/src/marctable/utils.py
+++ b/src/marctable/utils.py
@@ -146,7 +146,7 @@ def process_records(
                 subfields = mapping[field.tag]
 
                 # if subfields aren't specified stringify them
-                if subfields is None:
+                if "*" in subfields:
                     key = f"F{field.tag}"
                     if marc.get_field(field.tag).repeatable:
                         lst = r.get(key, [])
@@ -159,23 +159,22 @@ def process_records(
                         s = _stringify_field(field)
                         r[key] = s
 
-                # otherwise only add the subfields that were requested in the mapping
-                else:
-                    for sf in field.subfields:
-                        if sf.code not in subfields:
-                            continue
+                # look for requested subfields
+                for sf in field.subfields:
+                    if sf.code not in subfields:
+                        continue
 
-                        key = f"F{field.tag}{sf.code}"
-                        if marc.get_subfield(field.tag, sf.code).repeatable:
-                            value: ListOrString = r.get(key, [])
-                            assert isinstance(value, list), (
-                                "Repeatable field contains a string instead of list"
-                            )
-                            value.append(sf.value)
-                        else:
-                            value = sf.value
+                    key = f"F{field.tag}{sf.code}"
+                    if marc.get_subfield(field.tag, sf.code).repeatable:
+                        value: ListOrString = r.get(key, [])
+                        assert isinstance(value, list), (
+                            "Repeatable field contains a string instead of list"
+                        )
+                        value.append(sf.value)
+                    else:
+                        value = sf.value
 
-                        r[key] = value
+                    r[key] = value
 
             rows.append(r)
 
@@ -191,27 +190,53 @@ def _stringify_field(field: Field) -> str:
 
 def _mapping(rules: list, avram_file: Optional[BinaryIO] = None) -> dict:
     """
-    unpack the mapping rules into a dictionary for easy lookup
+    Unpack the mapping rules into a dictionary for easy lookup. "*" signifies
+    that the concatenated subfields are desired.
 
     >>> _mapping(["245", "260ac"])
-    {'245': None, '260': ['a', 'c']}
+    {'245': ['*'], '260': ['a', 'c']}
+
+    The full field can be extracted alongside its subfields by using "*" too:
+
+    >>> _mapping(["260", "260ac"])
+    {'260': ['*', 'a', 'c']}
     """
     marc = MARC.from_avram(avram_file)
+
+    # if there are no rules default to all fields
     if rules is None or len(rules) == 0:
         rules = [field.tag for field in marc.fields]
 
-    m = {}
+    m: dict[str, list[str]] = {}
     for rule in rules:
         field_tag = rule[0:3]
         if marc.get_field(field_tag) is None:
             raise Exception(f"unknown MARC field in mapping rule: {rule}")
 
-        subfields = set(list(rule[3:]))
-        for subfield_code in subfields:
-            if marc.get_subfield(field_tag, subfield_code) is None:
-                raise Exception(f"unknown MARC subfield in mapping rule: {rule}")
+        subfields = []
 
-        m[field_tag] = subfields or None
+        # if they just want the whole field
+        if field_tag == rule:
+            subfields.append("*")
+
+        # otherwise they want specific subfields
+        else:
+            for subfield_code in set(list(rule[3:])):
+                if marc.get_subfield(field_tag, subfield_code) is None:
+                    raise Exception(
+                        f"unknown MARC field/subfield in mapping rule: {rule}"
+                    )
+                subfields.append(subfield_code)
+
+        # it helps when testing that the values appear in order
+        subfields = list(sorted(subfields))
+
+        # look to see if we need to add the rule to an existing one
+        # this is important so that ["245", "245a"] works properly.
+        if field_tag in m:
+            m[field_tag].extend(subfields)
+        else:
+            m[field_tag] = subfields
 
     return m
 
@@ -222,10 +247,10 @@ def _columns(mapping: dict) -> list:
     """
     cols = []
     for field_tag, subfields in mapping.items():
-        if subfields is None:
-            cols.append(f"F{field_tag}")
-        else:
-            for sf in subfields:
+        for sf in subfields:
+            if sf == "*":
+                cols.append(f"F{field_tag}")
+            else:
                 cols.append(f"F{field_tag}{sf}")
     return cols
 
@@ -237,12 +262,12 @@ def _make_pandas_schema(
     mapping = _mapping(rules, avram_file)
     schema = {}
     for field_tag, subfields in mapping.items():
-        if subfields is None:
-            schema[f"F{field_tag}"] = (
-                "object" if marc.get_field(field_tag).repeatable else "str"
-            )
-        else:
-            for sf in subfields:
+        for sf in subfields:
+            if sf == "*":
+                schema[f"F{field_tag}"] = (
+                    "object" if marc.get_field(field_tag).repeatable else "str"
+                )
+            else:
                 schema[f"F{field_tag}{sf}"] = (
                     "object" if marc.get_subfield(field_tag, sf).repeatable else "str"
                 )
@@ -258,15 +283,16 @@ def _make_parquet_schema(
     pyarrow_str = pyarrow.string()
     pyarrow_list_of_str = pyarrow.list_(pyarrow.string())
 
+    # construct a pyarrow column schema based on the mapping
     cols: List[Tuple[str, pyarrow.DataType]] = []
     for field_tag, subfields in mapping.items():
-        if subfields is None:
-            if marc.get_field(field_tag).repeatable:
-                cols.append((f"F{field_tag}", pyarrow_list_of_str))
+        for sf_code in subfields:
+            if sf_code == "*":
+                if marc.get_field(field_tag).repeatable:
+                    cols.append((f"F{field_tag}", pyarrow_list_of_str))
+                else:
+                    cols.append((f"F{field_tag}", pyarrow_str))
             else:
-                cols.append((f"F{field_tag}", pyarrow_str))
-        else:
-            for sf_code in subfields:
                 sf = marc.get_subfield(field_tag, sf_code)
                 if sf is not None and sf.repeatable:
                     cols.append((f"F{field_tag}{sf}", pyarrow_list_of_str))

--- a/tests/test_marc.py
+++ b/tests/test_marc.py
@@ -2,9 +2,7 @@ import json
 from io import StringIO
 
 import pytest
-from pymarc import MARCReader
 from marctable.marc import MARC, SchemaFieldError, SchemaSubfieldError, crawl
-from marctable.utils import _mapping, to_dataframe
 
 marc = MARC.from_avram()
 
@@ -68,47 +66,3 @@ def test_repeatable_field() -> None:
     assert f650.tag == "650"
     assert f650.label == "Subject Added Entry-Topical Term"
     assert f650.repeatable is True
-
-
-def test_custom_fields_df() -> None:
-    df = to_dataframe(
-        MARCReader(open("test-data/utf8.marc", "rb")), rules=["245", "650"]
-    )
-    assert len(df) == 10612
-    # should only have two columns in the dataframe
-    assert len(df.columns) == 2
-    assert df.columns[0] == "F245"
-    assert df.columns[1] == "F650"
-    assert (
-        df.iloc[0]["F245"]
-        == "Leak testing CD-ROM [computer file] / technical editors, Charles N. "
-        "Jackson, Jr., Charles N. Sherlock ; editor, Patrick O. Moore."
-    )
-    assert df.iloc[0]["F650"] == ["Leak detectors.", "Gas leakage."]
-
-
-def test_custom_subfields_df() -> None:
-    df = to_dataframe(
-        MARCReader(open("test-data/utf8.marc", "rb")), rules=["245a", "260c"]
-    )
-    assert len(df) == 10612
-    assert len(df.columns) == 2
-    assert df.columns[0] == "F245a"
-    assert df.columns[1] == "F260c"
-    # 245a is not repeatable
-    assert df.iloc[0]["F245a"] == "Leak testing CD-ROM"
-    # 260c is repeatable
-    assert df.iloc[0]["F260c"] == ["c2000."]
-
-
-def test_field_mapping() -> None:
-    m = _mapping(["245", "650"])
-    assert m["245"] is None
-    assert m["650"] is None
-
-
-def test_field_subfield_mapping() -> None:
-    m = _mapping(["245a", "650ax", "260"])
-    assert set(m["245"]) == set(["a"])
-    assert set(m["650"]) == set(["a", "x"])
-    assert m["260"] is None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@ import pathlib
 
 import pandas
 from pymarc import MARCReader
-from marctable.utils import dataframe_iter, to_csv, to_dataframe, to_parquet
+from marctable.utils import dataframe_iter, to_csv, to_dataframe, to_parquet, _mapping
 
 
 def test_to_dataframe() -> None:
@@ -78,3 +78,60 @@ def test_to_parquet_with_rules() -> None:
     df = pandas.read_parquet("test-data/utf8.parquet")
     assert len(df) == 10612
     assert len(df.columns) == 3
+
+
+def test_mapping() -> None:
+    assert _mapping(["245"]) == {"245": ["*"]}
+    assert _mapping(["245", "650"]) == {"245": ["*"], "650": ["*"]}
+    assert _mapping(["040", "040a"]) == {"040": ["*", "a"]}
+    assert _mapping(["245a", "650ax", "260"]) == {
+        "245": ["a"],
+        "650": ["a", "x"],
+        "260": ["*"],
+    }
+
+
+def test_field_and_subfield(tmp_path) -> None:
+    """
+    Ensure we can specify both the field as a whole and individual subfields.
+    """
+    csv_path = tmp_path / "test.csv"
+    to_csv(
+        MARCReader(open("test-data/utf8.marc", "rb")),
+        csv_path.open("w"),
+        rules=["040", "040a"],
+    )
+    df = pandas.read_csv(csv_path)
+    assert len(df) == 10612
+    assert len(df.columns) == 2
+
+
+def test_custom_fields_df() -> None:
+    df = to_dataframe(
+        MARCReader(open("test-data/utf8.marc", "rb")), rules=["245", "650"]
+    )
+    assert len(df) == 10612
+    # should only have two columns in the dataframe
+    assert len(df.columns) == 2
+    assert df.columns[0] == "F245"
+    assert df.columns[1] == "F650"
+    assert (
+        df.iloc[0]["F245"]
+        == "Leak testing CD-ROM [computer file] / technical editors, Charles N. "
+        "Jackson, Jr., Charles N. Sherlock ; editor, Patrick O. Moore."
+    )
+    assert df.iloc[0]["F650"] == ["Leak detectors.", "Gas leakage."]
+
+
+def test_custom_subfields_df() -> None:
+    df = to_dataframe(
+        MARCReader(open("test-data/utf8.marc", "rb")), rules=["245a", "260c"]
+    )
+    assert len(df) == 10612
+    assert len(df.columns) == 2
+    assert df.columns[0] == "F245a"
+    assert df.columns[1] == "F260c"
+    # 245a is not repeatable
+    assert df.iloc[0]["F245a"] == "Leak testing CD-ROM"
+    # 260c is repeatable
+    assert df.iloc[0]["F260c"] == ["c2000."]


### PR DESCRIPTION
The rules can now include the full field (concatenated subfields) and individual subfields. For example:

```
uv run marctable csv --rule 245 --rule 245ab marc.dat
```

Will return a CSV with columns "F245", "F245a", "F245b". Previously it was just returning columns "F245a" and "F245b".

We're also moving from mypy to ty for type checking.
