### PR TITLE
Fix parquet schema

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "marctable"
-version = "0.7.0"
+version = "0.7.1"
 description = "Convert MARC to CSV and Parquet"
 authors = [{ name = "Ed Summers", email = "ehs@pobox.com" }]
 license = { file = "LICENSE" }

--- a/src/marctable/marc.py
+++ b/src/marctable/marc.py
@@ -79,7 +79,9 @@ class Field:
         }
 
         if self.subfields is not None:
-            d["subfields"]: dict[str, dict] = {sf.code: sf.to_dict() for sf in self.subfields}
+            d["subfields"]: dict[str, dict] = {
+                sf.code: sf.to_dict() for sf in self.subfields
+            }
 
         return d
 

--- a/src/marctable/utils.py
+++ b/src/marctable/utils.py
@@ -295,7 +295,7 @@ def _make_parquet_schema(
             else:
                 sf = marc.get_subfield(field_tag, sf_code)
                 if sf is not None and sf.repeatable:
-                    cols.append((f"F{field_tag}{sf}", pyarrow_list_of_str))
+                    cols.append((f"F{field_tag}{sf.code}", pyarrow_list_of_str))
                 else:
-                    cols.append((f"F{field_tag}{sf}", pyarrow_str))
+                    cols.append((f"F{field_tag}{sf.code}", pyarrow_str))
     return pyarrow.schema(cols)  # type: ignore[arg-type]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -77,7 +77,7 @@ def test_to_parquet_with_rules() -> None:
     assert pathlib.Path("test-data/utf8.parquet").is_file()
     df = pandas.read_parquet("test-data/utf8.parquet")
     assert len(df) == 10612
-    assert len(df.columns) == 3
+    assert list(df.columns) == ["F001", "F245", "F650v"]
 
 
 def test_mapping() -> None:


### PR DESCRIPTION
The parquet schema had incorrect subfield columns in the last release. This fixes that.
