### PR TITLE
Add Column dataclass and unified columns parameter to all to_* functions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS.md
+
+## Environment
+
+This project uses [uv](https://docs.astral.sh/uv/) for dependency management. All commands should be run via `uv run` so they use the project's virtual environment automatically — no need to activate `.venv` manually.
+
+## Common commands
+
+Run the test suite:
+
+```
+uv run pytest
+```
+
+Run the type checker:
+
+```
+uv run ty check
+```
+
+Run the linter:
+
+```
+uv run ruff check
+```
+
+Run the formatter:
+
+```
+uv run ruff format
+```
+
+Run the CLI:
+
+```
+uv run marctable
+```

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ FLDR,F001,F003,F005,F006,F007,F008,F010,F013,F015,F016,F017,F018,F020,F022,F023,
 01278cmm a2200313 a 4500,   00022453 ,DLC,20020304100307.0,,['cj||||'],000119s2000    mau    f   b        eng  ,   00022453 ,,,,,,,,,,,,,,,,,,,,,,,DLC DLC DLC,,,,,,,,,['TK7871.6'],,,,,,,,,,,,['621.382 13'],,,,,,"Kolundžija, Branko M.",,,,,,,,,"WIPL-D [computer file] : electromagnetic modeling of composite metallic and dielectric structures / Branko Kolundzija, Jovan S. Ognjanovic, and Tapan K. Sarkar.",,,,,,,Computer program.,,,"['Boston : Artech House, c2000.']",,,,"[""2 computer disks ; 3 1/2 in. + 1 user's manual.""]",,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,['Title from disk label.'],,,,,,,,,,,,,,,"['Provides analysis of metallic and/or dielectric/magnetic structures such as antennas, scatterers, and passive microwave circuits.']",['Engineers.'],,,,,,,,,,,['System requirements: IBM-compatible PC (Pentium preferred); 16MB RAM; Windows 95 or NT; 6MB hard disk space; mouse.'],,,,,,,,,,,,,,,,,,,,,,,,,,,,,,"['Antennas (Electronics) Software.', 'Microwave circuits Software.', 'Electromagnetic waves Software.']",,,,,,,,,,"['Ognjanovic, Jovan S.', 'Sarkar, Tapan (Tapan K.)']",,,,,,,,,,,,,,,,,,,,,,,,,,,
 ```
 
-If you only want specific field and subfields you can pass in one or more rules. This will extract the `245` subfield `a`, the 650 subfields `a` and `v`, and the entirety of the  `500` fields, all as separate columns:
+If you only want specific fields and subfields you can pass in one or more `--column` options. This will extract the `245` subfield `a`, the `650` subfields `a` and `v`, and the entirety of the `500` fields, all as separate columns:
 
 ```
-$ marctable csv --rule 245a --rule 650av --rule 500 data.marc data.csv 
+$ marctable csv --column 245a --column 650av --column 500 data.marc data.csv 
 ```
 
 ```csv
@@ -65,10 +65,10 @@ You can also write the data as a [Parquet] file, which has advantages in that it
 $ marctable parquet data.marc data.parquet
 ```
 
-or with rules:
+or with explicit columns:
 
 ```
-$ marctable parquet --rules 245a --rule 650a data.marc data.parquet
+$ marctable parquet --column 245a --column 650a data.marc data.parquet
 ```
 
 ### JSONL
@@ -89,7 +89,7 @@ $ marctable avram
 
 ## Library
 
-You can use marctable in your own programs. You need to pass various functions either a list of `pymarc.Record` objects or a generator of `pymarc.Record` objects:
+You can use marctable in your own programs. You need to pass various functions either a list of `pymarc.Record` objects or a generator/iterator of `pymarc.Record` objects:
 
 ```python
 from pymarc import MARCReader
@@ -103,6 +103,28 @@ to_parquet(records, open("records.parquet", "wb"))
 ```
 
 There are similar `to_csv()`, `to_jsonl()` and `to_dataframe()` functions as well. Be careful with `to_dataframe()` because unlike the other functions it will load all the records into memory.
+
+You can also define custom columns using the `Column` class, which takes a name and a function that receives a `pymarc.Record` and returns a value:
+
+```python
+from pymarc import MARCReader
+from marctable import to_parquet, Column
+
+records = MARCReader(open("records.dat", "rb"))
+
+to_parquet(
+    records,
+    open("records.parquet", "wb"),
+    columns=[
+        "245a",
+        "650",
+        Column("subject_count", lambda r: len(r.get_fields("650", "651", "600"))),
+        Column("is_electronic", lambda r: r.leader[6] == "m"),
+    ],
+)
+```
+
+String columns and `Column` objects can be freely mixed in the same list.
 
 ## Develop
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "marctable"
-version = "0.7.2"
+version = "0.8.0"
 description = "Convert MARC to CSV and Parquet"
 authors = [{ name = "Ed Summers", email = "ehs@pobox.com" }]
 license = { file = "LICENSE" }
@@ -56,6 +56,6 @@ markers = [
 ]
       
 
-[tool.mypy]
-warn_no_return = false
-exclude = "^dist.*"
+[tool.pyright]
+venvPath = "."
+venv = ".venv"

--- a/src/marctable/__init__.py
+++ b/src/marctable/__init__.py
@@ -6,7 +6,9 @@ from pymarc import MARCReader
 from pymarc.marcxml import parse_xml_to_array
 
 from marctable.marc import crawl
-from marctable.utils import to_csv, to_jsonl, to_parquet
+from marctable.utils import Column, ColumnSpec, to_csv, to_jsonl, to_parquet
+
+__all__ = ["Column", "ColumnSpec", "to_csv", "to_jsonl", "to_parquet"]
 
 
 @click.group()
@@ -23,13 +25,13 @@ def io_params(f: Callable) -> Callable:
     return f
 
 
-def rule_params(f: Callable) -> Callable:
+def column_params(f: Callable) -> Callable:
     f = click.option(
-        "--rule",
-        "-r",
-        "rules",
+        "--column",
+        "-c",
+        "columns",
         multiple=True,
-        help="Specify a rule for extracting, e.g. 245 or 245a or 245ac",
+        help="Specify a column to extract, e.g. 245 or 245a or 245ac",
     )(f)
     f = click.option(
         "--batch", "-b", default=1000, help="Batch n records when converting"
@@ -53,46 +55,58 @@ def avram_params(f: Callable) -> Callable:
 
 @cli.command()
 @io_params
-@rule_params
+@column_params
 @avram_params
 def csv(
-    infile: BinaryIO, outfile: TextIO, rules: list, batch: int, avram_file: BinaryIO
+    infile: BinaryIO, outfile: TextIO, columns: list, batch: int, avram_file: BinaryIO
 ) -> None:
     """
     Convert MARC to CSV.
     """
     to_csv(
-        _records(infile), outfile, rules=rules, batch_size=batch, avram_file=avram_file
+        _records(infile),
+        outfile,
+        columns=list(columns),
+        batch_size=batch,
+        avram_file=avram_file,
     )
 
 
 @cli.command()
 @io_params
-@rule_params
+@column_params
 @avram_params
 def parquet(
-    infile: BinaryIO, outfile: IO[Any], rules: list, batch: int, avram_file: BinaryIO
+    infile: BinaryIO, outfile: IO[Any], columns: list, batch: int, avram_file: BinaryIO
 ) -> None:
     """
     Convert MARC to Parquet.
     """
     to_parquet(
-        _records(infile), outfile, rules=rules, batch_size=batch, avram_file=avram_file
+        _records(infile),
+        outfile,
+        columns=list(columns),
+        batch_size=batch,
+        avram_file=avram_file,
     )
 
 
 @cli.command()
 @io_params
-@rule_params
+@column_params
 @avram_params
 def jsonl(
-    infile: BinaryIO, outfile: BinaryIO, rules: list, batch: int, avram_file: BinaryIO
+    infile: BinaryIO, outfile: BinaryIO, columns: list, batch: int, avram_file: BinaryIO
 ) -> None:
     """
     Convert MARC to JSON Lines (JSONL)
     """
     to_jsonl(
-        _records(infile), outfile, rules=rules, batch_size=batch, avram_file=avram_file
+        _records(infile),
+        outfile,
+        columns=list(columns),
+        batch_size=batch,
+        avram_file=avram_file,
     )
 
 

--- a/src/marctable/marc.py
+++ b/src/marctable/marc.py
@@ -15,7 +15,7 @@ import re
 import sys
 import time
 from functools import cache
-from typing import IO, Generator, List, Optional, Type
+from typing import IO, Any, Generator, List, Optional, Type
 from urllib.parse import urljoin
 
 import requests
@@ -70,8 +70,8 @@ class Field:
             subfields=[Subfield.from_dict(d) for d in d.get("subfields", {}).values()],
         )
 
-    def to_dict(self) -> dict[str, str | bool | None]:
-        d = {
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
             "tag": self.tag,
             "label": self.label,
             "repeatable": self.repeatable,
@@ -79,9 +79,7 @@ class Field:
         }
 
         if self.subfields is not None:
-            d["subfields"]: dict[str, dict] = {
-                sf.code: sf.to_dict() for sf in self.subfields
-            }
+            d["subfields"] = {sf.code: sf.to_dict() for sf in self.subfields}
 
         return d
 

--- a/src/marctable/utils.py
+++ b/src/marctable/utils.py
@@ -1,8 +1,12 @@
 import json
 from collections.abc import Iterator
+from dataclasses import dataclass
 from itertools import batched
 from typing import (
+    IO,
+    Any,
     BinaryIO,
+    Callable,
     Dict,
     Generator,
     List,
@@ -10,27 +14,43 @@ from typing import (
     TextIO,
     Tuple,
     Union,
-    IO,
-    Any,
 )
 
 import pandas
 import pyarrow
 from pandas import DataFrame
 from pyarrow.parquet import ParquetWriter
-from pymarc import Record, Field, MARCReader
+from pymarc import Field, MARCReader, Record
 
 from .marc import MARC
 
-# type alises to shorten annotations
+# type aliases to shorten annotations
 ListOrString = Union[str, List[str]]
 Records = List[Record] | Iterator[Record] | MARCReader
+
+
+@dataclass
+class Column:
+    name: str
+    fn: Callable[[Record], Any]
+
+
+ColumnSpec = str | Column
+
+
+def _split_columns(
+    columns: list[ColumnSpec],
+) -> tuple[list[str], list[Column]]:
+    """Split a columns list into MARC string rules and Column objects."""
+    str_rules = [c for c in columns if isinstance(c, str)]
+    col_objects = [c for c in columns if isinstance(c, Column)]
+    return str_rules, col_objects
 
 
 def to_csv(
     records: Records,
     csv_output: TextIO,
-    rules: list = [],
+    columns: list[ColumnSpec] = [],
     batch_size: int = 1000,
     avram_file: Optional[BinaryIO] = None,
 ) -> None:
@@ -39,7 +59,7 @@ def to_csv(
     """
     first_batch = True
     for df in dataframe_iter(
-        records, rules=rules, batch_size=batch_size, avram_file=avram_file
+        records, columns=columns, batch_size=batch_size, avram_file=avram_file
     ):
         df.to_csv(csv_output, header=first_batch, index=False)
         first_batch = False
@@ -48,7 +68,7 @@ def to_csv(
 def to_jsonl(
     records: Records,
     jsonl_output: BinaryIO,
-    rules: list = [],
+    columns: list[ColumnSpec] = [],
     batch_size: int = 1000,
     avram_file: Optional[BinaryIO] = None,
 ) -> None:
@@ -56,7 +76,7 @@ def to_jsonl(
     Convert MARC to JSON Lines (JSONL).
     """
     for records_batch in process_records(
-        records, rules=rules, batch_size=batch_size, avram_file=avram_file
+        records, columns=columns, batch_size=batch_size, avram_file=avram_file
     ):
         for record in records_batch:
             jsonl_output.write(json.dumps(record).encode("utf8") + b"\n")
@@ -65,17 +85,17 @@ def to_jsonl(
 def to_parquet(
     records: Records,
     parquet_output: IO[Any],
-    rules: list = [],
+    columns: list[ColumnSpec] = [],
     batch_size: int = 1000,
     avram_file: Optional[BinaryIO] = None,
 ) -> None:
     """
     Convert MARC to Parquet.
     """
-    schema = _make_parquet_schema(rules, avram_file)
+    schema = _make_parquet_schema(columns, avram_file)
     writer = ParquetWriter(parquet_output, schema, compression="snappy")
     for records_batch in process_records(
-        records, rules=rules, batch_size=batch_size, avram_file=avram_file
+        records, columns=columns, batch_size=batch_size, avram_file=avram_file
     ):
         table = pyarrow.Table.from_pylist(records_batch, schema)
         writer.write_table(table)
@@ -85,8 +105,8 @@ def to_parquet(
 
 def to_dataframe(
     records: Records,
-    rules: list = [],
-    batch_size=1000,
+    columns: list[ColumnSpec] = [],
+    batch_size: int = 1000,
     avram_file: Optional[BinaryIO] = None,
 ) -> DataFrame:
     """
@@ -94,37 +114,38 @@ def to_dataframe(
     WARNING: It will build the entire DataFrame in memory, so be careful!
     """
     return pandas.concat(
-        list(dataframe_iter(records, rules, batch_size, avram_file)), axis=0
+        list(dataframe_iter(records, columns, batch_size, avram_file)), axis=0
     )
 
 
 def dataframe_iter(
     records: Records,
-    rules: list = [],
+    columns: list[ColumnSpec] = [],
     batch_size: int = 1000,
     avram_file: Optional[BinaryIO] = None,
 ) -> Generator[DataFrame, None, None]:
     """
     Read the records and generates Panda Data Frames of a given size.
     """
-    columns = _columns(_mapping(rules, avram_file))
+    col_names = _columns(columns, avram_file)
     for records_batch in process_records(
-        records, rules, batch_size, avram_file=avram_file
+        records, columns, batch_size, avram_file=avram_file
     ):
-        yield DataFrame.from_records(records_batch, columns=columns)
+        yield DataFrame.from_records(records_batch, columns=col_names)
 
 
 def process_records(
     records: Records,
-    rules: list = [],
+    columns: list[ColumnSpec] = [],
     batch_size: int = 1000,
     avram_file: Optional[BinaryIO] = None,
 ) -> Generator[List[Dict], None, None]:
     """
     Iterate through MARCRecords and return a generator of batches of records
-    represented as a list of dictionaries, which are constructed with the given rules.
+    represented as a list of dictionaries, which are constructed with the given columns.
     """
-    mapping = _mapping(rules, avram_file)
+    str_rules, col_objects = _split_columns(columns)
+    mapping = _mapping(str_rules, col_objects, avram_file)
     marc = MARC.from_avram(avram_file)
 
     for batch in batched(records, batch_size):
@@ -177,6 +198,10 @@ def process_records(
 
                     r[key] = value
 
+            # now add any function based columns
+            for col in col_objects:
+                r[col.name] = col.fn(record)
+
             rows.append(r)
 
         yield rows
@@ -189,23 +214,28 @@ def _stringify_field(field: Field) -> str:
         return " ".join([sf.value for sf in field.subfields])
 
 
-def _mapping(rules: list, avram_file: Optional[BinaryIO] = None) -> dict:
+def _mapping(
+    rules: list, col_objects: list, avram_file: Optional[BinaryIO] = None
+) -> dict:
     """
     Unpack the mapping rules into a dictionary for easy lookup. "*" signifies
     that the concatenated subfields are desired.
 
-    >>> _mapping(["245", "260ac"])
+    >>> _mapping(["245", "260ac"], [])
     {'245': ['*'], '260': ['a', 'c']}
 
     The full field can be extracted alongside its subfields by using "*" too:
 
-    >>> _mapping(["260", "260ac"])
+    >>> _mapping(["260", "260ac"], [])
     {'260': ['*', 'a', 'c']}
+
+    The col_objects need to be passed in because when they are in use we don't
+    want to return the default mapping for all MARC fields.
     """
     marc = MARC.from_avram(avram_file)
 
-    # if there are no rules default to all fields
-    if rules is None or len(rules) == 0:
+    # if there are no rules AND col_objects is not being used, default to all MARC fields
+    if (rules is None or len(rules) == 0) and len(col_objects) == 0:
         rules = [field.tag for field in marc.fields]
 
     m: dict[str, list[str]] = {}
@@ -242,44 +272,35 @@ def _mapping(rules: list, avram_file: Optional[BinaryIO] = None) -> dict:
     return m
 
 
-def _columns(mapping: dict) -> list:
+def _columns(
+    columns: list[ColumnSpec], avram_file: Optional[BinaryIO] = None
+) -> list[str]:
     """
-    unpack the mapping to get a list of columns for the table
+    Unpack the columns to get a list of column names for the table.
     """
-    cols = []
+    str_rules, col_objects = _split_columns(columns)
+    mapping = _mapping(str_rules, col_objects, avram_file)
+
+    cols: list[str] = []
     for field_tag, subfields in mapping.items():
         for sf in subfields:
             if sf == "*":
                 cols.append(f"F{field_tag}")
             else:
                 cols.append(f"F{field_tag}{sf}")
+
+    for col in col_objects:
+        cols.append(col.name)
+
     return cols
 
 
-def _make_pandas_schema(
-    rules: list, avram_file: Optional[BinaryIO] = None
-) -> Dict[str, str]:
-    marc = MARC.from_avram(avram_file)
-    mapping = _mapping(rules, avram_file)
-    schema = {}
-    for field_tag, subfields in mapping.items():
-        for sf in subfields:
-            if sf == "*":
-                schema[f"F{field_tag}"] = (
-                    "object" if marc.get_field(field_tag).repeatable else "str"
-                )
-            else:
-                schema[f"F{field_tag}{sf}"] = (
-                    "object" if marc.get_subfield(field_tag, sf).repeatable else "str"
-                )
-    return schema
-
-
 def _make_parquet_schema(
-    rules: list, avram_file: Optional[BinaryIO] = None
+    columns: list[ColumnSpec], avram_file: Optional[BinaryIO] = None
 ) -> pyarrow.Schema:
     marc = MARC.from_avram(avram_file)
-    mapping = _mapping(rules, avram_file)
+    str_rules, col_objects = _split_columns(columns)
+    mapping = _mapping(str_rules, col_objects, avram_file)
 
     pyarrow_str = pyarrow.string()
     pyarrow_list_of_str = pyarrow.list_(pyarrow.string())
@@ -299,4 +320,8 @@ def _make_parquet_schema(
                     cols.append((f"F{field_tag}{sf.code}", pyarrow_list_of_str))
                 else:
                     cols.append((f"F{field_tag}{sf.code}", pyarrow_str))
+
+    for col in col_objects:
+        cols.append((col.name, pyarrow_str))
+
     return pyarrow.schema(cols)  # type: ignore[arg-type]

--- a/tests/test_marc.py
+++ b/tests/test_marc.py
@@ -51,7 +51,7 @@ def test_get_subfield() -> None:
     with pytest.raises(
         SchemaSubfieldError, match="- is not a valid subfield in field 245"
     ):
-        marc.get_subfield("245", "-") is None
+        assert marc.get_subfield("245", "-") is None
 
 
 def test_non_repeatable_field() -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,14 @@ import pathlib
 
 import pandas
 from pymarc import MARCReader
-from marctable.utils import dataframe_iter, to_csv, to_dataframe, to_parquet, _mapping
+from marctable.utils import (
+    dataframe_iter,
+    to_csv,
+    to_dataframe,
+    to_parquet,
+    Column,
+    _mapping,
+)
 
 
 def test_to_dataframe() -> None:
@@ -34,7 +41,7 @@ def test_to_csv() -> None:
         open("test-data/utf8.csv", "w"),
         batch_size=1000,
     )
-    df = pandas.read_csv("test-data/utf8.csv")
+    df = pandas.read_csv("test-data/utf8.csv", low_memory=False)
     assert len(df) == 10612
     assert len(df.columns) == 216
     assert (
@@ -67,12 +74,12 @@ def test_to_parquet_iter() -> None:
     assert len(df.columns) == 216
 
 
-def test_to_parquet_with_rules() -> None:
+def test_to_parquet_with_columns() -> None:
     to_parquet(
         MARCReader(open("test-data/utf8.marc", "rb")),
         open("test-data/utf8.parquet", "wb"),
         batch_size=1000,
-        rules=["001", "245", "650v"],
+        columns=["001", "245", "650v"],
     )
     assert pathlib.Path("test-data/utf8.parquet").is_file()
     df = pandas.read_parquet("test-data/utf8.parquet")
@@ -81,14 +88,20 @@ def test_to_parquet_with_rules() -> None:
 
 
 def test_mapping() -> None:
-    assert _mapping(["245"]) == {"245": ["*"]}
-    assert _mapping(["245", "650"]) == {"245": ["*"], "650": ["*"]}
-    assert _mapping(["040", "040a"]) == {"040": ["*", "a"]}
-    assert _mapping(["245a", "650ax", "260"]) == {
+    assert _mapping(["245"], []) == {"245": ["*"]}
+    assert _mapping(["245", "650"], []) == {"245": ["*"], "650": ["*"]}
+    assert _mapping(["040", "040a"], []) == {"040": ["*", "a"]}
+    assert _mapping(["245a", "650ax", "260"], []) == {
         "245": ["a"],
         "650": ["a", "x"],
         "260": ["*"],
     }
+    assert len(_mapping([], [])) == 216, (
+        "passing in no rules and no col_objects results in the default mapping being returned (all fields)"
+    )
+    assert _mapping([], [Column("field_count", lambda r: len(r.fields))]) == {}, (
+        "passing in no rules but some col_objects results in the empty dictionary being returned"
+    )
 
 
 def test_field_and_subfield(tmp_path) -> None:
@@ -99,7 +112,7 @@ def test_field_and_subfield(tmp_path) -> None:
     to_csv(
         MARCReader(open("test-data/utf8.marc", "rb")),
         csv_path.open("w"),
-        rules=["040", "040a"],
+        columns=["040", "040a"],
     )
     df = pandas.read_csv(csv_path)
     assert len(df) == 10612
@@ -108,7 +121,7 @@ def test_field_and_subfield(tmp_path) -> None:
 
 def test_custom_fields_df() -> None:
     df = to_dataframe(
-        MARCReader(open("test-data/utf8.marc", "rb")), rules=["245", "650"]
+        MARCReader(open("test-data/utf8.marc", "rb")), columns=["245", "650"]
     )
     assert len(df) == 10612
     # should only have two columns in the dataframe
@@ -125,7 +138,7 @@ def test_custom_fields_df() -> None:
 
 def test_custom_subfields_df() -> None:
     df = to_dataframe(
-        MARCReader(open("test-data/utf8.marc", "rb")), rules=["245a", "260c"]
+        MARCReader(open("test-data/utf8.marc", "rb")), columns=["245a", "260c"]
     )
     assert len(df) == 10612
     assert len(df.columns) == 2
@@ -135,3 +148,41 @@ def test_custom_subfields_df() -> None:
     assert df.iloc[0]["F245a"] == "Leak testing CD-ROM"
     # 260c is repeatable
     assert df.iloc[0]["F260c"] == ["c2000."]
+
+
+def test_column_func_mix() -> None:
+    df = to_dataframe(
+        MARCReader(open("test-data/utf8.marc", "rb")),
+        columns=[
+            "245a",
+            "260c",
+            Column("field_count", lambda r: len(r.fields)),
+        ],
+    )
+    assert len(df) == 10612
+    assert len(df.columns) == 3
+    assert df.columns[0] == "F245a"
+    assert df.columns[1] == "F260c"
+
+    # 245a is not repeatable
+    assert df.iloc[0]["F245a"] == "Leak testing CD-ROM"
+
+    # 260c is repeatable
+    assert df.iloc[0]["F260c"] == ["c2000."]
+
+    # function based column was populated
+    assert df.iloc[0]["field_count"] == 27
+
+
+def test_one_column_func() -> None:
+    df = to_dataframe(
+        MARCReader(open("test-data/utf8.marc", "rb")),
+        columns=[
+            Column("field_count", lambda r: len(r.fields)),
+        ],
+    )
+    assert len(df) == 10612
+    assert len(df.columns) == 1
+
+    # function based column was populated
+    assert df.iloc[0]["field_count"] == 27


### PR DESCRIPTION
Replace the rules parameter with a columns parameter that accepts either
string MARC field rules (e.g. "245a") or Column(name, fn) objects for
custom computed columns. Column objects receive a pymarc.Record and return
a value appended to each output row.

The CLI --rule/-r flag is replaced with --column/-c.

Add AGENTS.md documenting uv-based development commands.
